### PR TITLE
Add boards table and Whiteboard.create_board

### DIFF
--- a/lib/whiteboard.ex
+++ b/lib/whiteboard.ex
@@ -1,9 +1,9 @@
 defmodule Whiteboard do
-  @moduledoc """
-  Whiteboard keeps the contexts that define your domain
-  and business logic.
+  alias Whiteboard.{Board, Repo}
 
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
-  """
+  def create_board(name) do
+    %Board{}
+    |> Board.changeset(%{"name" => name})
+    |> Repo.insert()
+  end
 end

--- a/lib/whiteboard/board.ex
+++ b/lib/whiteboard/board.ex
@@ -1,0 +1,19 @@
+defmodule Whiteboard.Board do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @derive {Phoenix.Param, key: :id}
+  schema "boards" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(board, attrs) do
+    board
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/priv/repo/migrations/20181206161732_create_boards.exs
+++ b/priv/repo/migrations/20181206161732_create_boards.exs
@@ -1,0 +1,12 @@
+defmodule Whiteboard.Repo.Migrations.CreateBoards do
+  use Ecto.Migration
+
+  def change do
+    create table(:boards, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :name, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/whiteboard_test.exs
+++ b/test/whiteboard_test.exs
@@ -1,0 +1,17 @@
+defmodule WhiteboardTest do
+  use Whiteboard.DataCase, async: true
+
+  describe "new_board/1" do
+    test "creates a new board with given name" do
+      {:ok, board} = Whiteboard.create_board("hello board")
+
+      assert board.name == "hello board"
+    end
+
+    test "returns error if no name is given" do
+      {:error, changeset} = Whiteboard.create_board("")
+
+      assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+end


### PR DESCRIPTION
Adds a boards table. For now it only has a name. We also set the id to be a uuid, so that we can more easily expose that as the whiteboard id.

We also add `Whiteboard.create_board/1` which creates a whiteboard.