### PR TITLE
Persist paths to database

### DIFF
--- a/lib/whiteboard.ex
+++ b/lib/whiteboard.ex
@@ -1,11 +1,25 @@
 defmodule Whiteboard do
   alias Whiteboard.{Board, Repo}
 
+  import Ecto.Query
+
   def get_board!(id), do: Repo.get!(Board, id)
 
   def create_board(name) do
     %Board{}
     |> Board.changeset(%{"name" => name})
     |> Repo.insert()
+  end
+
+  def all_paths(board_id) do
+    Board.Path |> where([p], p.board_id == ^board_id) |> Repo.all()
+  end
+
+  def upsert_path(board_id, path_id, points) do
+    changes = %{"board_id" => board_id, "id" => path_id, "points" => points}
+
+    %Board.Path{}
+    |> Board.Path.changeset(changes)
+    |> Repo.insert(on_conflict: {:replace, [:points]}, conflict_target: :id)
   end
 end

--- a/lib/whiteboard/application.ex
+++ b/lib/whiteboard/application.ex
@@ -8,12 +8,8 @@ defmodule Whiteboard.Application do
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [
-      # Start the Ecto repository
       Whiteboard.Repo,
-      # Start the endpoint when the application starts
       WhiteboardWeb.Endpoint
-      # Starts a worker by calling: Whiteboard.Worker.start_link(arg)
-      # {Whiteboard.Worker, arg},
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/whiteboard/board/path.ex
+++ b/lib/whiteboard/board/path.ex
@@ -1,0 +1,21 @@
+defmodule Whiteboard.Board.Path do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: false}
+  @derive {Phoenix.Param, key: :id}
+  @derive {Jason.Encoder, only: [:id, :points]}
+  schema "paths" do
+    field :points, {:array, :map}
+    belongs_to :board, Whiteboard.Board, type: :binary_id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(path, attrs) do
+    path
+    |> cast(attrs, [:id, :points, :board_id])
+    |> validate_required([:id, :points, :board_id])
+  end
+end

--- a/lib/whiteboard_web/channels/board_channel.ex
+++ b/lib/whiteboard_web/channels/board_channel.ex
@@ -2,11 +2,18 @@ defmodule WhiteboardWeb.BoardChannel do
   use Phoenix.Channel
 
   def join("board:" <> board_id, _msg, socket) do
-    {:ok, assign(socket, :board_id, board_id)}
+    board_paths = Whiteboard.all_paths(board_id)
+
+    {:ok, board_paths, assign(socket, :board_id, board_id)}
   end
 
   def handle_in("new_event", payload, socket) do
     broadcast_from!(socket, "new_event", payload)
+
+    %{"id" => path_id, "points" => points} = payload
+
+    Whiteboard.upsert_path(socket.assigns.board_id, path_id, points)
+
     {:noreply, socket}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Whiteboard.MixProject do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["assets.compile", "ecto.create --quiet", "ecto.migrate", "test"],
+      test: ["ecto.create --quiet", "ecto.migrate", "test"],
       "assets.compile": &compile_assets/1
     ]
   end

--- a/priv/repo/migrations/20181207155240_create_paths.exs
+++ b/priv/repo/migrations/20181207155240_create_paths.exs
@@ -1,0 +1,13 @@
+defmodule Whiteboard.Repo.Migrations.CreatePaths do
+  use Ecto.Migration
+
+  def change do
+    create table(:paths, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :board_id, references("boards", type: :uuid)
+      add :points, {:array, :map}, default: [], null: false
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,6 +1,12 @@
 defmodule Whiteboard.Factory do
-  def insert_board(name) do
+  def insert_board(name \\ "random board") do
     {:ok, board} = Whiteboard.create_board(name)
     board
+  end
+
+  def insert_path(board, points) do
+    path_id = Ecto.UUID.generate()
+    {:ok, path} = Whiteboard.upsert_path(board.id, path_id, points)
+    path
   end
 end

--- a/test/whiteboard_test.exs
+++ b/test/whiteboard_test.exs
@@ -1,6 +1,8 @@
 defmodule WhiteboardTest do
   use Whiteboard.DataCase, async: true
 
+  import Whiteboard.Factory
+
   describe "new_board/1" do
     test "creates a new board with given name" do
       {:ok, board} = Whiteboard.create_board("hello board")
@@ -12,6 +14,33 @@ defmodule WhiteboardTest do
       {:error, changeset} = Whiteboard.create_board("")
 
       assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+
+  describe "upsert_path/3" do
+    test "creates path if does not exist" do
+      board = insert_board()
+      path_id = Ecto.UUID.generate()
+      points = [%{"x" => 1, "y" => 2}]
+
+      {:ok, path} = Whiteboard.upsert_path(board.id, path_id, points)
+
+      assert path.points == points
+      assert path.board_id == board.id
+      assert path.id == path_id
+    end
+
+    test "updates path if it exists" do
+      board = insert_board()
+      points = [%{"x" => 1, "y" => 2}]
+      path = insert_path(board, points)
+
+      new_points = [%{"x" => 3, "y" => 4}]
+
+      {:ok, path} = Whiteboard.upsert_path(board.id, path.id, new_points)
+
+      assert path.points == new_points
+      assert path.board_id == board.id
     end
   end
 end

--- a/test/whiteboard_web/channels/board_channel_test.exs
+++ b/test/whiteboard_web/channels/board_channel_test.exs
@@ -1,0 +1,29 @@
+defmodule WhiteboardWeb.BoardChannelTest do
+  use WhiteboardWeb.ChannelCase
+
+  alias Whiteboard.Board.Path
+  alias Whiteboard.Repo
+  alias WhiteboardWeb.BoardChannel
+
+  describe "new_event" do
+    test "broadcast new even to all participants" do
+      payload = %{"id" => Ecto.UUID.generate(), "points" => [%{x: 1, y: 2}]}
+
+      "random board"
+      |> join_channel()
+      |> send_new_event(payload)
+
+      assert_broadcast("new_event", payload)
+    end
+  end
+
+  def send_new_event({:ok, _reply, socket}, payload) do
+    push(socket, "new_event", payload)
+  end
+
+  defp join_channel(board_name) do
+    WhiteboardWeb.UserSocket
+    |> socket("user_id", %{})
+    |> subscribe_and_join(BoardChannel, "board:" <> board_name)
+  end
+end


### PR DESCRIPTION
We now persist paths to the database and return a full list of all paths when user joins a channel.